### PR TITLE
README Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,21 @@
-MPU-9150
-====
+9 Degrees of Freedom - MPU-9150 Breakout
+========================================
 
-![https://www.sparkfun.com/products/11486](https://dlnmh9ip6v2uc.cloudfront.net/images/products/1/1/4/8/6/11486-01_small.jpg)
+[![9 Degrees of Freedom - MPU-9150 Breakout](https://dlnmh9ip6v2uc.cloudfront.net/images/products/1/1/4/8/6/11486-01_medium.jpg)  
+*9 Degrees of Freedom - MPU-9150 Breakout (SEN-11486)*](https://www.sparkfun.com/products/11486)
 
-These are the most up to date hardware and firmware files for the [MPU-9150 Breakout](https://www.sparkfun.com/products/11486) at SparkFun Electronics.
+The MPU-9150 is an accelerometer, gyro, and magnetometer all in a single package with an I2C interface. [The datasheet can be found here.](http://dlnmh9ip6v2uc.cloudfront.net/datasheets/Sensors/IMU/PS-MPU-9150A.pdf)
 
-The MPU-9150 is an accelerometer, gyro, and magnetometer all in a single package with an I2C interface. Here is the [datasheet](http://dlnmh9ip6v2uc.cloudfront.net/datasheets/Sensors/IMU/PS-MPU-9150A.pdf) 
+Repository Contents
+-------------------
 
-The hardware directory contains the Eagle design files and the firmware directory contains an Arduino library with an example that send raw sensor data out of the serial port. 
+* **/firmware** - An Arduino library with an example that sends raw sensor data out of the serial port
+* **/hardware** - All Eagle design files
 
-Hardware License
-====
-[Creative Commons Attribution-ShareAlike](http://creativecommons.org/licenses/by-sa/3.0/)
+License Information
+-------------------
+The hardware is released under [Creative Commons Share-alike 3.0](http://creativecommons.org/licenses/by-sa/3.0/).  
+The firmware is released under the [MIT License](http://opensource.org/licenses/MIT).
 
-Author: Aaron Weiss @ SparkFun Electonics
-
-Firmware License
-====
-From the original author [Jeff Rowberg](https://github.com/jrowberg/i2cdevlib), jeff@rowberg.net 
-Modified by Aaron Weiss, aaron@sparkfun.com
-
-The Arduino library code is placed under the MIT license:
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+Hardware author: Aaron Weiss @ SparkFun Electonics  
+Firmware original author: [Jeff Rowberg](https://github.com/jrowberg/i2cdevlib) (jeff@rowberg.net); modified by Aaron Weiss (aaron@sparkfun.com)


### PR DESCRIPTION
@a1ronzo - another readme cleanup.

The only major change here was removing the MIT license text and instead linking to the license on opensource.org. In general I think linking to licenses where they're hosted is easiest because it keeps the legalese out of our documents and one click away. An exception would be if we modify a standard license for a particular repository.
